### PR TITLE
Simple mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ On the client machine, run Wiretap in configure mode to build a config
 ./wiretap configure --port <port> --endpoint <socket> --routes <routes>
 ```
 
+* `--port` sets the listening port of the Client's Relay interface. It's set to 51820 by default. Note that the E2EE listening port does not need to be accessible to the Server
+* `--endpoint` tells the Server how to connect to the Client's Relay interface (the E2EE interfaces already know how to talk to each other if the Relay interfaces are working)
+* `--routes` is the equivalent of WireGuard's AllowedIPs setting. This tells the Client to route traffic that matches these IP ranges through Wiretap
+
 Following the example in the diagram:
 ```bash
 ./wiretap configure --port 1337 --endpoint 1.3.3.7:1337 --routes 10.0.0.0/24
@@ -99,7 +103,7 @@ Config File:  ./wiretap serve -f wiretap_server.conf
 ```
 
 > **Note**
-> Wiretap uses 2 WireGuard interfaces per node in order to safely and scalably chain together servers. See the [How It Works](#how-it-works) section for details
+> Wiretap uses 2 WireGuard interfaces per node in order to safely and scalably chain together servers. This means your client will bind to more than one port, but only the Relay Interface port needs to be accessible by the Server. See the [How It Works](#how-it-works) section for details
 
 Install the resulting config either by copying and pasting the output or by importing the new `wiretap_relay.conf` and `wiretap_e2ee.conf` files into WireGuard:
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Config File:  ./wiretap serve -f wiretap_server.conf
 ```
 
 > **Note**
-> Wiretap uses 2 WireGuard interfaces per node in order to safely and scalably chain together servers. This means your client will bind to more than one port, but only the Relay Interface port needs to be accessible by the Server. See the [How It Works](#how-it-works) section for details
+> Wiretap uses 2 WireGuard interfaces per node in order to safely and scalably chain together servers. This means your client will bind to more than one port, but only the Relay Interface port needs to be accessible by the Server. See the [How It Works](#how-it-works) section for details. Use `--simple` if your setup requires a single interface on the client
 
 Install the resulting config either by copying and pasting the output or by importing the new `wiretap_relay.conf` and `wiretap_e2ee.conf` files into WireGuard:
 

--- a/src/cmd/add_server.go
+++ b/src/cmd/add_server.go
@@ -320,7 +320,7 @@ func (c addServerCmdConfig) Run() {
 	// Copy to clipboard if requested.
 	var clipboardStatus string
 	if c.writeToClipboard {
-		err = clipboard.WriteAll(peer.CreateServerCommand(serverConfigRelay, serverConfigE2EE, "POSIX"))
+		err = clipboard.WriteAll(peer.CreateServerCommand(serverConfigRelay, serverConfigE2EE, peer.POSIX, false))
 		if err != nil {
 			clipboardStatus = fmt.Sprintf("%s %s", RedBold("clipboard:"), Red(fmt.Sprintf("error copying to clipboard: %v", err)))
 		} else {
@@ -347,8 +347,8 @@ func (c addServerCmdConfig) Run() {
 	fmt.Fprintln(color.Output)
 	fmt.Fprintln(color.Output, fileStatusServer)
 	fmt.Fprintln(color.Output)
-	fmt.Fprintln(color.Output, Cyan("POSIX Shell: "), Green(peer.CreateServerCommand(serverConfigRelay, serverConfigE2EE, "POSIX")))
-	fmt.Fprintln(color.Output, Cyan(" PowerShell: "), Green(peer.CreateServerCommand(serverConfigRelay, serverConfigE2EE, "POWERSHELL")))
+	fmt.Fprintln(color.Output, Cyan("POSIX Shell: "), Green(peer.CreateServerCommand(serverConfigRelay, serverConfigE2EE, peer.POSIX, false)))
+	fmt.Fprintln(color.Output, Cyan(" PowerShell: "), Green(peer.CreateServerCommand(serverConfigRelay, serverConfigE2EE, peer.PowerShell, false)))
 	fmt.Fprintln(color.Output, Cyan("Config File: "), Green("./wiretap serve -f "+c.configFileServer))
 	fmt.Fprintln(color.Output)
 	if c.writeToClipboard {


### PR DESCRIPTION
Addresses #11

Use `--simple` with `configure` to only generate a config for a single interface. The copyable server commands will tell the `serve` command to also startup in simple mode. 

Multihop features don't work in this mode (add server, add client, status, etc.)