### PR TITLE
default port matches endpoint; documentation improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -619,21 +619,25 @@ If you have *no* outbound or inbound UDP access, you can still use Wiretap, but 
 
 Another great tool that has similar cross-platform capabilities to Wiretap is [Chisel](https://github.com/jpillora/chisel). We can use chisel to forward a UDP port to the remote system over TCP. To use:
 
-Run chisel server on the client system, specifying a TCP port you can reach from the server system:
+Run `chisel server` on the wiretap client system, specifying a TCP port you can reach from the server system:
 ```bash
 ./chisel server --port 8080
 ```
 
-On the server system, forward the port with this command using the same TCP port you specified in the previous command and using the ListenPort you specified when configuring Wiretap (the default is 51820). The format is `<localport>:0.0.0.0:<remoteport>/udp`.
+> [!Note]
+> In this example we run the `chisel server ...` command on the Wiretap *client*, and `chisel client ...` command  on a Wiretap *server*. This is because the chisel "client" always tries to reach out and connect to the chisel "server," whereas Wiretap clients and servers are defined by their functionality since either can initiate the connection. 
 
-In this example, we're forwarding 51821/udp on the server to 51820 on the client:
+In this example, we're connecting chisel to the listener on 8080 (on the wiretap client) and forwarding 61820/udp from the Wiretap server to 51820 (any interface) on the Wiretap client:
 ```bash
-./chisel client <endpoint address>:8080 51821:0.0.0.0:51820/udp
+./chisel client <wiretap client address>:8080 61820:0.0.0.0:51820/udp
 ```
+- `8080` is the chisel listening port specified in the `chisel server` command above
+- `61820` is the localhost port on the Wiretap server that will be forwarded back to the Wiretap client.
+- `51820` is the port where the Wiretap client is listening (by default is the same port you specified in the `--endpoint` argument in the initial `wiretap configure` command)
 
-Finally, run Wiretap with the forwarded local port as your endpoint on the server system:
+Finally, run Wiretap on the remote server system with the forwarded localhost port in the `--endpoint`:
 ```bash
-WIRETAP_RELAY_INTERFACE_PRIVATEKEY=<key> WIRETAP_RELAY_PEER_PUBLICKEY=<key> WIRETAP_E2EE_INTERFACE_PRIVATEKEY=<key> WIRETAP_E2EE_PEER_PUBLICKEY=<key> WIRETAP_E2EE_PEER_ENDPOINT=172.16.0.1:51821 ./wiretap serve --endpoint localhost:51821
+WIRETAP_RELAY_INTERFACE_PRIVATEKEY=<key> WIRETAP_RELAY_PEER_PUBLICKEY=<key> WIRETAP_E2EE_INTERFACE_PRIVATEKEY=<key> WIRETAP_E2EE_PEER_PUBLICKEY=<key> WIRETAP_E2EE_PEER_ENDPOINT=172.16.0.1:51821 ./wiretap serve --endpoint localhost:61820
 ```
 
 ### Add Clients To Any Server
@@ -643,7 +647,7 @@ WIRETAP_RELAY_INTERFACE_PRIVATEKEY=<key> WIRETAP_RELAY_PEER_PUBLICKEY=<key> WIRE
 
 Clients can be attached to any server in the network by using the `--server-address <api-address>` argument when running `wiretap add client`. This allows a client on a different network than the first client to still gain access to all of the Wiretap network's routes. But this has some limitations.
 
-In this example, a new client (C2) is added to the second server in the right branch of a Wiretap network. This client will only be able to access routes via the right branch of the network (S3 and S4) and not the left branch (S1 or S2) because the branches are only joined through an existing client (C1), which does not route traffic from other clients:
+In this example, a new client (C2) is added to the second server in the right branch of a Wiretap network (S4). This client will only be able to access routes via the right branch of the network (S3 and S4) and not the left branch (S1 or S2) because the branches are only joined through an existing client (C1), which does not route traffic from other clients:
 
 ```
          ┌──────┐

--- a/src/cmd/add.go
+++ b/src/cmd/add.go
@@ -18,7 +18,7 @@ type addCmdConfig struct {
 var addCmdArgs = addCmdConfig{
 	endpoint:  Endpoint,
 	outbound:  false,
-	port:      -1,
+	port:      USE_ENDPOINT_PORT,
 	keepalive: Keepalive,
 }
 

--- a/src/cmd/add.go
+++ b/src/cmd/add.go
@@ -18,7 +18,7 @@ type addCmdConfig struct {
 var addCmdArgs = addCmdConfig{
 	endpoint:  Endpoint,
 	outbound:  false,
-	port:      Port,
+	port:      -1,
 	keepalive: Keepalive,
 }
 

--- a/src/cmd/add_client.go
+++ b/src/cmd/add_client.go
@@ -78,6 +78,18 @@ func (c addClientCmdConfig) Run() {
 	if len(baseConfigE2EE.GetAddresses()) == 1 {
 		disableV6 = true
 	}
+	
+	//Set deefault port to be the same as the port specified in the endpoint
+	/*
+	if addArgs.port == -1 {
+		strPort := strings.Split(addArgs.endpoint, ":")[1];
+		addArgs.port, err = strconv.Atoi(strPort);
+	    check("cannot extract port from endpoint argument", err);
+	}
+	*/
+	if addArgs.port == -1 {
+		addArgs.port = portFromEndpoint(addArgs.endpoint);
+	}
 
 	// Make new configs for client.
 	relayAddrs := []string{addresses.NextClientRelayAddr4.String() + "/32"}
@@ -85,7 +97,7 @@ func (c addClientCmdConfig) Run() {
 		relayAddrs = append(relayAddrs, addresses.NextClientRelayAddr6.String()+"/128")
 	}
 	clientConfigRelay, err := peer.GetConfig(peer.ConfigArgs{
-		ListenPort: addCmdArgs.port,
+		ListenPort: addArgs.port,
 		Addresses:  relayAddrs,
 	})
 	check("failed to generate client relay config", err)

--- a/src/cmd/add_client.go
+++ b/src/cmd/add_client.go
@@ -79,7 +79,7 @@ func (c addClientCmdConfig) Run() {
 		disableV6 = true
 	}
 	
-	if addArgs.port == -1 {
+	if addArgs.port == USE_ENDPOINT_PORT {
 		addArgs.port = portFromEndpoint(addArgs.endpoint);
 	}
 

--- a/src/cmd/add_client.go
+++ b/src/cmd/add_client.go
@@ -79,14 +79,6 @@ func (c addClientCmdConfig) Run() {
 		disableV6 = true
 	}
 	
-	//Set deefault port to be the same as the port specified in the endpoint
-	/*
-	if addArgs.port == -1 {
-		strPort := strings.Split(addArgs.endpoint, ":")[1];
-		addArgs.port, err = strconv.Atoi(strPort);
-	    check("cannot extract port from endpoint argument", err);
-	}
-	*/
 	if addArgs.port == -1 {
 		addArgs.port = portFromEndpoint(addArgs.endpoint);
 	}

--- a/src/cmd/add_server.go
+++ b/src/cmd/add_server.go
@@ -305,6 +305,11 @@ func (c addServerCmdConfig) Run() {
 		// Leaf server is the relay peer for the new server.
 		clientConfigRelay = leafServerConfigRelay
 	}
+	
+	// Use a reasonable default for server listening ports
+	if addArgs.port == -1 {
+		addArgs.port = Port;
+	}
 
 	if addArgs.port != Port {
 		err = serverConfigRelay.SetPort(addArgs.port)

--- a/src/cmd/add_server.go
+++ b/src/cmd/add_server.go
@@ -307,7 +307,7 @@ func (c addServerCmdConfig) Run() {
 	}
 	
 	// Use a reasonable default for server listening ports
-	if addArgs.port == -1 {
+	if addArgs.port == USE_ENDPOINT_PORT {
 		addArgs.port = Port;
 	}
 

--- a/src/cmd/configure.go
+++ b/src/cmd/configure.go
@@ -6,6 +6,7 @@ import (
 	"net/netip"
 	"os"
 	"strings"
+	//"strconv"
 	"wiretap/peer"
 
 	"github.com/atotto/clipboard"
@@ -39,10 +40,10 @@ type configureCmdConfig struct {
 // Defaults for configure command.
 // See root command for shared defaults.
 var configureCmdArgs = configureCmdConfig{
-	allowedIPs:       []string{"0.0.0.0/32"},
+	allowedIPs:       []string{"0.0.0.0/0"},
 	endpoint:         Endpoint,
 	outbound:         false,
-	port:             Port,
+	port:             -1,
 	configFileRelay:  ConfigRelay,
 	configFileE2EE:   ConfigE2EE,
 	configFileServer: ConfigServer,
@@ -76,9 +77,9 @@ func init() {
 	rootCmd.AddCommand(configureCmd)
 
 	configureCmd.Flags().StringSliceVarP(&configureCmdArgs.allowedIPs, "routes", "r", configureCmdArgs.allowedIPs, "CIDR IP ranges that will be routed through wiretap")
-	configureCmd.Flags().StringVarP(&configureCmdArgs.endpoint, "endpoint", "e", configureCmdArgs.endpoint, "socket address of wireguard listener that server will connect to (example \"1.2.3.4:51820\")")
-	configureCmd.Flags().BoolVar(&configureCmdArgs.outbound, "outbound", configureCmdArgs.outbound, "client will initiate handshake to server, set endpoint to server address")
-	configureCmd.Flags().IntVarP(&configureCmdArgs.port, "port", "p", configureCmdArgs.port, "port of local wireguard relay listener")
+	configureCmd.Flags().StringVarP(&configureCmdArgs.endpoint, "endpoint", "e", configureCmdArgs.endpoint, "IP:PORT of wireguard listener that server will connect to (example \"1.2.3.4:51820\")")
+	configureCmd.Flags().BoolVar(&configureCmdArgs.outbound, "outbound", configureCmdArgs.outbound, "client will initiate handshake to server; endpoint arg now specifies server's IP:PORT instead of client's")
+	configureCmd.Flags().IntVarP(&configureCmdArgs.port, "port", "p", configureCmdArgs.port, "port of local wireguard relay listener; default is to use the same port specified in the --endpoint argument")
 	configureCmd.Flags().StringVarP(&configureCmdArgs.configFileRelay, "relay-output", "", configureCmdArgs.configFileRelay, "wireguard relay config output filename")
 	configureCmd.Flags().StringVarP(&configureCmdArgs.configFileE2EE, "e2ee-output", "", configureCmdArgs.configFileE2EE, "wireguard E2EE config output filename")
 	configureCmd.Flags().StringVarP(&configureCmdArgs.configFileServer, "server-output", "s", configureCmdArgs.configFileServer, "wiretap server config output filename")
@@ -97,9 +98,9 @@ func init() {
 	configureCmd.Flags().IntVarP(&configureCmdArgs.mtu, "mtu", "m", configureCmdArgs.mtu, "tunnel MTU")
 	configureCmd.Flags().BoolVarP(&configureCmdArgs.disableV6, "disable-ipv6", "", configureCmdArgs.disableV6, "disables IPv6")
 
-	err := configureCmd.MarkFlagRequired("routes")
-	check("failed to mark flag required", err)
-	err = configureCmd.MarkFlagRequired("endpoint")
+	//err := configureCmd.MarkFlagRequired("routes")
+	//check("failed to mark flag required", err)
+	err := configureCmd.MarkFlagRequired("endpoint")
 	check("failed to mark flag required", err)
 
 	configureCmd.Flags().SortFlags = false
@@ -158,6 +159,18 @@ func (c configureCmdConfig) Run() {
 	clientE2EEAddrs := []string{c.clientAddr4E2EE}
 	if !c.disableV6 {
 		clientE2EEAddrs = append(clientE2EEAddrs, c.clientAddr6E2EE)
+	}
+	
+	//Set deefault port to be the same as the port specified in the endpoint
+	/*
+	if c.port == -1 {
+		strPort := strings.Split(c.endpoint, ":")[1];
+		c.port, err = strconv.Atoi(strPort);
+	    check("cannot extract port from endpoint argument", err);
+	}
+	*/
+	if c.port == -1 {
+		c.port = portFromEndpoint(c.endpoint);
 	}
 
 	clientConfigRelayArgs := peer.ConfigArgs{

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -6,6 +6,8 @@ import (
 	"log"
 	"net/netip"
 	"os"
+	"strings"
+	"strconv"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -83,4 +85,12 @@ func check(message string, err error) {
 	if err != nil {
 		log.Fatalf("%s: %v", message, err)
 	}
+}
+
+// Extract the port from the endpoint string 
+func portFromEndpoint(endpoint string) int {
+	strPort := strings.Split(endpoint, ":")[1];
+	p, err := strconv.Atoi(strPort);
+    check("cannot extract port from endpoint argument", err);
+	return p;
 }

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -5,13 +5,15 @@ import (
 	"fmt"
 	"log"
 	"net/netip"
+	"net"
 	"os"
-	"strings"
 	"strconv"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
+
+const USE_ENDPOINT_PORT = -1
 
 // Defaults shared by multiple commands.
 var (
@@ -89,8 +91,10 @@ func check(message string, err error) {
 
 // Extract the port from the endpoint string 
 func portFromEndpoint(endpoint string) int {
-	strPort := strings.Split(endpoint, ":")[1];
+	_, strPort, err := net.SplitHostPort(endpoint)
+	check("cannot extract port from endpoint argument", err);
+	
 	p, err := strconv.Atoi(strPort);
-    check("cannot extract port from endpoint argument", err);
+	check("cannot extract port from endpoint argument", err);
 	return p;
 }

--- a/src/cmd/serve.go
+++ b/src/cmd/serve.go
@@ -229,7 +229,6 @@ func init() {
 				"public-e2ee",
 				"endpoint-relay",
 				"endpoint-e2ee",
-				"port",
 				"allowed",
 				"ipv4-relay",
 				"ipv6-relay",


### PR DESCRIPTION
Default port for the `configure` command (i.e. `--port`) will now be set to whatever port was specified by the `--endpoint` command (instead of `51820`), since that argument is already required and they usually need to be the same anyway. 

Default route for the `configure` command is now a useful `0.0.0.0/0` instead of a useless `0.0.0.0/32`, and `--route` is no longer a required argument (closes #35). Added a note to the README about how this default may create networking issues in some cases. 

Various documentation improvements:
- Server config is not compatible with other wireguard tools
- Made more clear that clients can freely change their AllowedIPs
- The endpoint and API addresses must be for the same server in the `add server` command
- Servers will forget stuff that was configured via the API if they restart
- Clarified limitations of clients added to non-first-hop servers (or not all of them)
- Improved visual clarity of the example network diagrams