### PR TITLE
Help and filename improvements

### DIFF
--- a/src/cmd/add_client.go
+++ b/src/cmd/add_client.go
@@ -48,15 +48,33 @@ var addClientCmd = &cobra.Command{
 func init() {
 	addCmd.AddCommand(addClientCmd)
 
+	addClientCmd.Flags().StringVarP(&addClientCmdArgs.serverAddress, "server-address", "s", addClientCmdArgs.serverAddress, "API address of server that new client will connect to. By default new clients connect to existing relay servers")
+	addClientCmd.Flags().IntVarP(&addClientCmdArgs.mtu, "mtu", "m", addClientCmdArgs.mtu, "tunnel MTU")
 	addClientCmd.Flags().StringVarP(&addClientCmdArgs.outputConfigFileRelay, "relay-output", "", addClientCmdArgs.outputConfigFileRelay, "filename of output relay config file")
 	addClientCmd.Flags().StringVarP(&addClientCmdArgs.outputConfigFileE2EE, "e2ee-output", "", addClientCmdArgs.outputConfigFileE2EE, "filename of output E2EE config file")
 	addClientCmd.Flags().StringVarP(&addClientCmdArgs.inputConfigFileRelay, "relay-input", "", addClientCmdArgs.inputConfigFileRelay, "filename of input relay config file")
 	addClientCmd.Flags().StringVarP(&addClientCmdArgs.inputConfigFileE2EE, "e2ee-input", "", addClientCmdArgs.inputConfigFileE2EE, "filename of input E2EE config file")
-	addClientCmd.Flags().StringVarP(&addClientCmdArgs.serverAddress, "server-address", "s", addClientCmdArgs.serverAddress, "API address of server that new client will connect to. By default new clients connect to existing relay servers")
-	addClientCmd.Flags().IntVarP(&addClientCmdArgs.mtu, "mtu", "m", addClientCmdArgs.mtu, "tunnel MTU")
 
 	addClientCmd.Flags().SortFlags = false
 	addClientCmd.PersistentFlags().SortFlags = false
+	
+	helpFunc := addCmd.HelpFunc()
+	addCmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		if !ShowHidden {
+			for _, f := range []string{
+				"relay-output",
+				"e2ee-output",
+				"relay-input",
+				"e2ee-input",
+			} {
+				err := cmd.Flags().MarkHidden(f)
+				if err != nil {
+					fmt.Printf("Failed to hide flag %v: %v\n", f, err)
+				}
+			}
+		}
+		helpFunc(cmd, args)
+	})
 }
 
 func (c addClientCmdConfig) Run() {

--- a/src/cmd/add_server.go
+++ b/src/cmd/add_server.go
@@ -60,6 +60,25 @@ func init() {
 
 	addServerCmd.Flags().SortFlags = false
 	addServerCmd.PersistentFlags().SortFlags = false
+	
+	helpFunc := addCmd.HelpFunc()
+	addCmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		if !ShowHidden {
+			for _, f := range []string{
+				"relay-output",
+				"e2ee-output",
+				"relay-input",
+				"e2ee-input",
+				"server-output",
+			} {
+				err := cmd.Flags().MarkHidden(f)
+				if err != nil {
+					fmt.Printf("Failed to hide flag %v: %v\n", f, err)
+				}
+			}
+		}
+		helpFunc(cmd, args)
+	})
 }
 
 func (c addServerCmdConfig) Run() {

--- a/src/cmd/configure.go
+++ b/src/cmd/configure.go
@@ -86,16 +86,16 @@ func init() {
 	configureCmd.Flags().BoolVarP(&configureCmdArgs.simple, "simple", "", configureCmdArgs.simple, "disable multihop and multiclient features for a simpler setup")
 
 	configureCmd.Flags().StringVarP(&configureCmdArgs.apiAddr, "api", "0", configureCmdArgs.apiAddr, "address of server API service")
+	configureCmd.Flags().IntVarP(&configureCmdArgs.keepalive, "keepalive", "k", configureCmdArgs.keepalive, "tunnel keepalive in seconds, only applies to outbound handshakes")
+	configureCmd.Flags().IntVarP(&configureCmdArgs.mtu, "mtu", "m", configureCmdArgs.mtu, "tunnel MTU")
+	configureCmd.Flags().BoolVarP(&configureCmdArgs.disableV6, "disable-ipv6", "", configureCmdArgs.disableV6, "disables IPv6")
+	
 	configureCmd.Flags().StringVarP(&configureCmdArgs.clientAddr4Relay, "ipv4-relay", "", configureCmdArgs.clientAddr4Relay, "ipv4 relay address")
 	configureCmd.Flags().StringVarP(&configureCmdArgs.clientAddr6Relay, "ipv6-relay", "", configureCmdArgs.clientAddr6Relay, "ipv6 relay address")
 	configureCmd.Flags().StringVarP(&configureCmdArgs.clientAddr4E2EE, "ipv4-e2ee", "", configureCmdArgs.clientAddr4E2EE, "ipv4 e2ee address")
 	configureCmd.Flags().StringVarP(&configureCmdArgs.clientAddr6E2EE, "ipv6-e2ee", "", configureCmdArgs.clientAddr6E2EE, "ipv6 e2ee address")
 	configureCmd.Flags().StringVarP(&configureCmdArgs.serverAddr4Relay, "ipv4-relay-server", "", configureCmdArgs.serverAddr4Relay, "ipv4 relay address of server")
 	configureCmd.Flags().StringVarP(&configureCmdArgs.serverAddr6Relay, "ipv6-relay-server", "", configureCmdArgs.serverAddr6Relay, "ipv6 relay address of server")
-
-	configureCmd.Flags().IntVarP(&configureCmdArgs.keepalive, "keepalive", "k", configureCmdArgs.keepalive, "tunnel keepalive in seconds, only applies to outbound handshakes")
-	configureCmd.Flags().IntVarP(&configureCmdArgs.mtu, "mtu", "m", configureCmdArgs.mtu, "tunnel MTU")
-	configureCmd.Flags().BoolVarP(&configureCmdArgs.disableV6, "disable-ipv6", "", configureCmdArgs.disableV6, "disables IPv6")
 
 	err := configureCmd.MarkFlagRequired("routes")
 	check("failed to mark flag required", err)
@@ -107,7 +107,21 @@ func init() {
 	helpFunc := configureCmd.HelpFunc()
 	configureCmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
 		if !ShowHidden {
-			for _, f := range []string{"api", "ipv4-relay", "ipv6-relay", "ipv4-e2ee", "ipv6-e2ee", "ipv4-relay-server", "ipv6-relay-server", "keepalive", "mtu", "disable-ipv6"} {
+			for _, f := range []string{
+				"api", 
+				"ipv4-relay", 
+				"ipv6-relay", 
+				"ipv4-e2ee", 
+				"ipv6-e2ee", 
+				"ipv4-relay-server", 
+				"ipv6-relay-server", 
+				"keepalive", 
+				"mtu", 
+				"disable-ipv6",
+				"relay-output",
+				"e2ee-output",
+				"server-output",
+			} {
 				err := cmd.Flags().MarkHidden(f)
 				if err != nil {
 					fmt.Printf("Failed to hide flag %v: %v\n", f, err)

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -71,7 +71,7 @@ var rootCmd = &cobra.Command{
 
 // Execute starts command handling, called by main.
 func Execute() {
-	rootCmd.PersistentFlags().BoolVarP(&ShowHidden, "show-hidden", "", ShowHidden, "show hidden flag options")
+	rootCmd.PersistentFlags().BoolVarP(&ShowHidden, "show-hidden", "H", ShowHidden, "show hidden flag options")
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)

--- a/src/cmd/serve.go
+++ b/src/cmd/serve.go
@@ -117,17 +117,21 @@ func init() {
 
 	// Flags.
 	cmd.Flags().StringVarP(&serveCmd.configFile, "config-file", "f", serveCmd.configFile, "wireguard config file to read from")
+	cmd.Flags().IntP("port", "p", wiretapDefault.port, "listener port to use for relay connections")
 	cmd.Flags().BoolVarP(&serveCmd.quiet, "quiet", "q", serveCmd.quiet, "silence wiretap log messages")
 	cmd.Flags().BoolVarP(&serveCmd.debug, "debug", "d", serveCmd.debug, "enable wireguard log messages")
 	cmd.Flags().BoolVarP(&serveCmd.simple, "simple", "", serveCmd.simple, "disable multihop and multiclient features for a simpler setup")
+	cmd.Flags().BoolVarP(&serveCmd.disableV6, "disable-ipv6", "", serveCmd.disableV6, "disable ipv6")
 	cmd.Flags().BoolVarP(&serveCmd.logging, "log", "l", serveCmd.logging, "enable logging to file")
 	cmd.Flags().StringVarP(&serveCmd.logFile, "log-file", "o", serveCmd.logFile, "write log to this filename")
+	cmd.Flags().StringP("api", "0", wiretapDefault.apiAddr, "address of API service")
+	cmd.Flags().IntP("keepalive", "k", wiretapDefault.keepalive, "tunnel keepalive in seconds")
+	cmd.Flags().IntP("mtu", "m", wiretapDefault.mtu, "tunnel MTU")
 	cmd.Flags().UintVarP(&serveCmd.catchTimeout, "completion-timeout", "", serveCmd.catchTimeout, "time in ms for client to complete TCP connection to server")
 	cmd.Flags().UintVarP(&serveCmd.connTimeout, "conn-timeout", "", serveCmd.connTimeout, "time in ms for server to wait for outgoing TCP handshakes to complete")
 	cmd.Flags().UintVarP(&serveCmd.keepaliveIdle, "keepalive-idle", "", serveCmd.keepaliveIdle, "time in seconds before TCP keepalives are sent to client")
 	cmd.Flags().UintVarP(&serveCmd.keepaliveInterval, "keepalive-interval", "", serveCmd.keepaliveInterval, "time in seconds between TCP keepalives")
 	cmd.Flags().UintVarP(&serveCmd.keepaliveCount, "keepalive-count", "", serveCmd.keepaliveCount, "number of unacknowledged TCP keepalives before closing connection")
-	cmd.Flags().BoolVarP(&serveCmd.disableV6, "disable-ipv6", "", serveCmd.disableV6, "disable ipv6")
 
 	cmd.Flags().StringVarP(&serveCmd.clientAddr4Relay, "ipv4-relay-client", "", serveCmd.clientAddr4Relay, "ipv4 relay address of client")
 	cmd.Flags().StringVarP(&serveCmd.clientAddr6Relay, "ipv6-relay-client", "", serveCmd.clientAddr6Relay, "ipv6 relay address of client")
@@ -151,15 +155,11 @@ func init() {
 	cmd.Flags().StringP("public-e2ee", "", "", "wireguard public key of remote peer for E2EE interface")
 	cmd.Flags().StringP("endpoint-relay", "", wiretapDefault.endpointRelay, "socket address of remote peer that server will connect to (example \"1.2.3.4:51820\")")
 	cmd.Flags().StringP("endpoint-e2ee", "", wiretapDefault.endpointE2EE, "socket address of remote peer's e2ee interface that server will connect to (example \"1.2.3.4:51820\")")
-	cmd.Flags().IntP("port", "p", wiretapDefault.port, "wireguard listener port")
 	cmd.Flags().StringP("allowed", "a", wiretapDefault.allowedIPs, "comma-separated list of CIDR IP ranges to associate with peer")
 	cmd.Flags().StringP("ipv4-relay", "", wiretapDefault.serverAddr4Relay, "ipv4 relay address")
 	cmd.Flags().StringP("ipv6-relay", "", wiretapDefault.serverAddr6Relay, "ipv6 relay address")
 	cmd.Flags().StringP("ipv4-e2ee", "", wiretapDefault.serverAddr4E2EE, "ipv4 e2ee address")
 	cmd.Flags().StringP("ipv6-e2ee", "", wiretapDefault.serverAddr6E2EE, "ipv6 e2ee address")
-	cmd.Flags().StringP("api", "0", wiretapDefault.apiAddr, "address of API service")
-	cmd.Flags().IntP("keepalive", "k", wiretapDefault.keepalive, "tunnel keepalive in seconds")
-	cmd.Flags().IntP("mtu", "m", wiretapDefault.mtu, "tunnel MTU")
 
 	// Bind deprecated flags to viper.
 	err = viper.BindPFlag("Relay.Interface.privatekey", cmd.Flags().Lookup("private-relay"))

--- a/src/peer/peer.go
+++ b/src/peer/peer.go
@@ -83,7 +83,7 @@ func GetNextPrefixesForPeers(peers []PeerConfig) []netip.Prefix {
 
 // Add number to filename if it already exists.
 func FindAvailableFilename(f string) string {
-	count := 1
+	count := 2
 	ext := filepath.Ext(f)
 	basename := strings.TrimSuffix(f, ext)
 	for {
@@ -91,7 +91,7 @@ func FindAvailableFilename(f string) string {
 		if os.IsNotExist(err) {
 			break
 		}
-		f = fmt.Sprintf("%s_%d%s", basename, count, ext)
+		f = fmt.Sprintf("%s%d%s", basename, count, ext)
 		count += 1
 	}
 


### PR DESCRIPTION
Linked `-H` to `--show-hidden` to make it easier and more intuitive to get the extra help options. 

Removed extra _ from numbered filenames to make tab-completion a lot easier

Additional config files now start their numbering at 2 instead of 1 so numbered server config filenames match up with the default API address (at least initially). Also makes it easier to quickly tell how many config files you have because the highest number matches the count. 

Re-arranged various arguments in help menus so that more important/useful ones are near the top (mostly the ones important enough to have a shorthand arg). 

Moved some less-useful arguments to the hidden list, also making things more consistent between commands. 