### PR TITLE
fixed configure's outbound port behavior

### DIFF
--- a/src/cmd/configure.go
+++ b/src/cmd/configure.go
@@ -77,8 +77,8 @@ func init() {
 
 	configureCmd.Flags().StringSliceVarP(&configureCmdArgs.allowedIPs, "routes", "r", configureCmdArgs.allowedIPs, "[REQUIRED] CIDR IP ranges that will be routed through wiretap (example \"10.0.0.1/24\")")
 	configureCmd.Flags().StringVarP(&configureCmdArgs.endpoint, "endpoint", "e", configureCmdArgs.endpoint, "[REQUIRED] IP:PORT (or [IP]:PORT for IPv6) of wireguard listener that server will connect to (example \"1.2.3.4:51820\")")
-	configureCmd.Flags().BoolVar(&configureCmdArgs.outbound, "outbound", configureCmdArgs.outbound, "client will initiate handshake to server; --endpoint now specifies server's listening socket instead of client's")
-	configureCmd.Flags().IntVarP(&configureCmdArgs.port, "port", "p", configureCmdArgs.port, "listener port for local wireguard relay; default is to use the same port specified by --endpoint")
+	configureCmd.Flags().BoolVar(&configureCmdArgs.outbound, "outbound", configureCmdArgs.outbound, "client will initiate handshake to server; --endpoint now specifies server's listening socket instead of client's, and --port assigns the server's listening port instead of client's")
+	configureCmd.Flags().IntVarP(&configureCmdArgs.port, "port", "p", configureCmdArgs.port, "listener port for wireguard relay. Default is to copy the --endpoint port. If --outbound, sets port for the server; else for the client.")
 	configureCmd.Flags().StringVarP(&configureCmdArgs.configFileRelay, "relay-output", "", configureCmdArgs.configFileRelay, "wireguard relay config output filename")
 	configureCmd.Flags().StringVarP(&configureCmdArgs.configFileE2EE, "e2ee-output", "", configureCmdArgs.configFileE2EE, "wireguard E2EE config output filename")
 	configureCmd.Flags().StringVarP(&configureCmdArgs.configFileServer, "server-output", "s", configureCmdArgs.configFileServer, "wiretap server config output filename")
@@ -175,15 +175,28 @@ func (c configureCmdConfig) Run() {
 	}
 	
 	if c.port == USE_ENDPOINT_PORT {
-		c.port = portFromEndpoint(c.endpoint);
+		c.port = portFromEndpoint(c.endpoint)
 	}
 	
-	err = serverConfigRelay.SetPort(Port)
+	// We only configure one of these (based on --outbound or not)
+	// The other must be manually changed in the configs/command/envs
+	var clientPort int;
+	var serverPort int;
+	
+	if c.outbound {
+		clientPort = Port
+		serverPort = c.port
+	} else {
+		clientPort = c.port
+		serverPort = Port
+	}
+	
+	err = serverConfigRelay.SetPort(serverPort)
 	check("failed to set port", err)
 	
 
 	clientConfigRelayArgs := peer.ConfigArgs{
-		ListenPort: c.port,
+		ListenPort: clientPort,
 		Peers: []peer.PeerConfigArgs{
 			{
 				PublicKey: serverConfigRelay.GetPublicKey(),


### PR DESCRIPTION
Forgot to account for how `configure`'s `--outbound` option would need to handle default ports. This fixes it to be correct. 

Related: Overloading the `port` command is making it hard to document behavior with and without `--outbound` since both client and server need a port set in most cases, so in the future that should be split into `--client-port` and `--server-port` or similar. Currently `configure` has no way to set both ports, one always has to be changed manually in the resulting configs. 