### PR TITLE
Fixes for Gorelease 2.2

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -8,7 +8,12 @@ on:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    env:
+      flags: ""
     steps:
+      - if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+        # Allows manually running this on an untagged commit without actually generating a release
+        run: echo "flags=--snapshot" >> $GITHUB_ENV
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -19,22 +24,13 @@ jobs:
           go-version: "1.20"
           cache: true
           cache-dependency-path: src/go.sum
-      - name: Check GoReleaser Config
-        uses: goreleaser/goreleaser-action@v6
-        with:
-          distribution: goreleaser
-          version: latest
-          args: check
-          workdir: ./src
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
           # either 'goreleaser' (default) or 'goreleaser-pro'
           distribution: goreleaser
-          version: latest
-          args: release --clean
+          version: '~> v2'
+          args: release --clean ${{ env.flags }}
           workdir: ./src
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -24,6 +24,15 @@ jobs:
           go-version: "1.20"
           cache: true
           cache-dependency-path: src/go.sum
+      - name: Check GoReleaser Config
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: '~> v2'
+          args: check
+          workdir: ./src
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/src/.goreleaser.yaml
+++ b/src/.goreleaser.yaml
@@ -1,3 +1,4 @@
+version: 2
 before:
   hooks:
     - go mod tidy
@@ -25,7 +26,7 @@ archives:
 checksum:
   name_template: "checksums.txt"
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 changelog:
   use: github-native
 #  sort: asc


### PR DESCRIPTION
Also added some conditional flags to make it easier to manually test the CI process on any commit without actually publishing a release. 