### PR TITLE
Server Network Interface Enumeration

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,9 @@ Once the client configs have been imported and Wireguard is started, you can vie
   ╰─────────────────────╯
 ```
 
+> [!TIP]
+> Add the `--network-info` flag to this command to get a list of each Server host's network interfaces and associated CIDR addresses. 
+
 ## Add Server (Optional)
 
 <div align="center">

--- a/src/api/api.go
+++ b/src/api/api.go
@@ -89,6 +89,30 @@ func ServerInfo(apiAddr netip.AddrPort) (peer.Config, peer.Config, error) {
 	return *configs.RelayConfig, *configs.E2EEConfig, nil
 }
 
+func ServerInterfaces(apiAddr netip.AddrPort) (serverapi.HostInterfaces, error) {
+	//Generate a placeholder interface list to display the error later
+	emptyResponse := serverapi.HostInterfaces{}
+	emptyResponse.Interfaces = []serverapi.HostInterface{serverapi.HostInterface{
+		Name: "",
+	}}
+
+	body, err := makeRequest(request{
+		URL:    makeUrl(apiAddr, "serverinterfaces", []string{}),
+		Method: "GET",
+	})
+	if err != nil {
+		return emptyResponse, err
+	}
+
+	var interfaces serverapi.HostInterfaces
+	err = json.Unmarshal(body, &interfaces)
+	if err != nil {
+		return emptyResponse, err
+	}
+
+	return interfaces, nil
+}
+
 func AllocateNode(apiAddr netip.AddrPort, peerType peer.PeerType) (serverapi.NetworkState, error) {
 	body, err := makeRequest(request{
 		URL:    makeUrl(apiAddr, "allocate", []string{fmt.Sprintf("type=%d", peerType)}),

--- a/src/api/api.go
+++ b/src/api/api.go
@@ -26,6 +26,9 @@ type request struct {
 	Body   []byte
 }
 
+// Re-export the server api struct so files importing this package can access it
+type HostInterface serverapi.HostInterface
+
 // MakeRequest attempts to send an API query to the Wiretap server.
 func makeRequest(req request) ([]byte, error) {
 	client := &http.Client{Timeout: 3 * time.Second}
@@ -89,25 +92,19 @@ func ServerInfo(apiAddr netip.AddrPort) (peer.Config, peer.Config, error) {
 	return *configs.RelayConfig, *configs.E2EEConfig, nil
 }
 
-func ServerInterfaces(apiAddr netip.AddrPort) (serverapi.HostInterfaces, error) {
-	//Generate a placeholder interface list to display the error later
-	emptyResponse := serverapi.HostInterfaces{}
-	emptyResponse.Interfaces = []serverapi.HostInterface{serverapi.HostInterface{
-		Name: "",
-	}}
-
+func ServerInterfaces(apiAddr netip.AddrPort) ([]HostInterface, error) {
 	body, err := makeRequest(request{
 		URL:    makeUrl(apiAddr, "serverinterfaces", []string{}),
 		Method: "GET",
 	})
 	if err != nil {
-		return emptyResponse, err
+		return nil, err
 	}
 
-	var interfaces serverapi.HostInterfaces
+	var interfaces []HostInterface
 	err = json.Unmarshal(body, &interfaces)
 	if err != nil {
-		return emptyResponse, err
+		return nil, err
 	}
 
 	return interfaces, nil

--- a/src/cmd/status.go
+++ b/src/cmd/status.go
@@ -11,9 +11,11 @@ import (
 
 	"wiretap/api"
 	"wiretap/peer"
+	serverapi "wiretap/transport/api"
 )
 
 type statusCmdConfig struct {
+	networkInfo     bool
 	configFileRelay string
 	configFileE2EE  string
 }
@@ -21,6 +23,7 @@ type statusCmdConfig struct {
 // Defaults for status command.
 // See root command for shared defaults.
 var statusCmd = statusCmdConfig{
+	networkInfo:     false,
 	configFileRelay: ConfigRelay,
 	configFileE2EE:  ConfigE2EE,
 }
@@ -39,6 +42,7 @@ func init() {
 
 	rootCmd.AddCommand(cmd)
 
+	cmd.Flags().BoolVarP(&statusCmd.networkInfo, "network-info", "n", statusCmd.networkInfo, "Display network info for each online server node")
 	cmd.Flags().StringVarP(&statusCmd.configFileRelay, "relay", "1", statusCmd.configFileRelay, "wireguard relay config input filename")
 	cmd.Flags().StringVarP(&statusCmd.configFileE2EE, "e2ee", "2", statusCmd.configFileE2EE, "wireguard E2EE config input filename")
 
@@ -46,22 +50,23 @@ func init() {
 }
 
 // Run attempts to parse config files into a network diagram.
-func (c statusCmdConfig) Run() {
+func (cc statusCmdConfig) Run() {
 	// Start building tree.
 	type Node struct {
 		peerConfig  peer.PeerConfig
 		relayConfig peer.Config
 		e2eeConfig  peer.Config
 		children    []*Node
+		networkInfo serverapi.HostInterfaces
 		error       string
 	}
 
 	var err error
 
 	// Parse the relay and e2ee config files
-	clientConfigRelay, err := peer.ParseConfig(c.configFileRelay)
+	clientConfigRelay, err := peer.ParseConfig(cc.configFileRelay)
 	check("failed to parse relay config file", err)
-	clientConfigE2EE, err := peer.ParseConfig(c.configFileE2EE)
+	clientConfigE2EE, err := peer.ParseConfig(cc.configFileE2EE)
 	check("failed to parse e2ee config file", err)
 
 	client := Node{
@@ -81,15 +86,24 @@ func (c statusCmdConfig) Run() {
 		relayConfig, e2eeConfig, err := api.ServerInfo(netip.AddrPortFrom(ep.GetApiAddr(), uint16(ApiPort)))
 		if err != nil {
 			errorNodes = append(errorNodes, Node{
-				peerConfig:  ep,
-				error:       err.Error(),
+				peerConfig: ep,
+				error:      err.Error(),
 			})
-			
+
 		} else {
+			interfaces := serverapi.HostInterfaces{}
+			if cc.networkInfo {
+				interfaces, err = api.ServerInterfaces(netip.AddrPortFrom(ep.GetApiAddr(), uint16(ApiPort)))
+				if err != nil {
+					interfaces.Interfaces[0].Name = "ERROR"
+				}
+			}
+
 			nodes[relayConfig.GetPublicKey()] = Node{
 				peerConfig:  ep,
 				relayConfig: relayConfig,
 				e2eeConfig:  e2eeConfig,
+				networkInfo: interfaces,
 			}
 		}
 	}
@@ -131,19 +145,43 @@ func (c statusCmdConfig) Run() {
 			ips := []string{}
 			var api string
 			for j, a := range c.peerConfig.GetAllowedIPs() {
-				if j == len(c.peerConfig.GetAllowedIPs()) - 1 {
+				if j == len(c.peerConfig.GetAllowedIPs())-1 {
 					api = a.IP.String()
 				} else {
 					ips = append(ips, a.String())
 				}
 			}
-			t.AddChild(tree.NodeString(fmt.Sprintf(`server
+
+			nodeString := fmt.Sprintf(
+`server
  nickname: %v 
     relay: %v... 
      e2ee: %v... 
    
       api: %v 
-   routes: %v `, c.peerConfig.GetNickname(), c.relayConfig.GetPublicKey()[:8], c.e2eeConfig.GetPublicKey()[:8], api, strings.Join(ips, ","))))
+   routes: %v `, 
+   				c.peerConfig.GetNickname(), 
+   				c.relayConfig.GetPublicKey()[:8], 
+				c.e2eeConfig.GetPublicKey()[:8], 
+				api, 
+				strings.Join(ips, ","),
+			)
+			
+			if cc.networkInfo {
+				nodeString += `
+
+Network Interfaces:
+-------------------
+`
+				for _, ifx := range c.networkInfo.Interfaces {
+					nodeString += fmt.Sprintf("%v:\n", ifx.Name)
+					for _, a := range ifx.Addrs {
+						nodeString += strings.Repeat(" ", 2) + a.String() + "\n"
+					}
+				}
+			}
+
+			t.AddChild(tree.NodeString(nodeString))
 			child, err := t.Child(0)
 			check("could not build tree", err)
 			treeTraversal(node.children[i], child)
@@ -156,31 +194,39 @@ func (c statusCmdConfig) Run() {
 	fmt.Println()
 	fmt.Fprintln(color.Output, WhiteBold(t))
 	fmt.Println()
-	
+
 	if len(errorNodes) > 0 {
 		// Display known peers that we had issues connecting to
 		fmt.Fprintln(color.Output, WhiteBold("Peers with Errors:"))
 		fmt.Println()
-		
+
 		for _, node := range errorNodes {
 			ips := []string{}
 			var api string
 			for j, a := range node.peerConfig.GetAllowedIPs() {
-				if j == len(node.peerConfig.GetAllowedIPs()) - 1 {
+				if j == len(node.peerConfig.GetAllowedIPs())-1 {
 					api = a.IP.String()
 				} else {
 					ips = append(ips, a.String())
 				}
 			}
-			
-			t = tree.NewTree(tree.NodeString(fmt.Sprintf(`server
+
+			nodeString := fmt.Sprintf(
+`server
 
  nickname: %v 
-      e2ee: %v... 
-       api: %v 
-    routes: %v 
+     e2ee: %v... 
+      api: %v 
+   routes: %v 
+		   
+ error: %v`, 
+ 				node.peerConfig.GetNickname(), 
+ 				node.peerConfig.GetPublicKey().String()[:8], 
+				api, strings.Join(ips, ","), 
+				errorWrap(node.error, 80),
+			)
 
- error: %v`, node.peerConfig.GetNickname(), node.peerConfig.GetPublicKey().String()[:8], api, strings.Join(ips, ","), errorWrap(node.error, 80))))
+			t = tree.NewTree(tree.NodeString(nodeString))
 			fmt.Fprintln(color.Output, WhiteBold(t))
 		}
 	}

--- a/src/transport/api/api.go
+++ b/src/transport/api/api.go
@@ -63,10 +63,6 @@ type HostInterface struct {
 	Addrs []net.IPNet
 }
 
-type HostInterfaces struct {
-	Interfaces []HostInterface
-}
-
 type AddAllowedIPsRequest struct {
 	PublicKey  wgtypes.Key
 	AllowedIPs []net.IPNet
@@ -207,7 +203,7 @@ func handleServerInterfaces() http.HandlerFunc {
 			return
 		}
 
-		interfaces := HostInterfaces{}
+		var interfaces []HostInterface
 		ifs, err := net.Interfaces()
 		if err != nil {
 			log.Printf("API Error: %v", err)
@@ -230,7 +226,7 @@ func handleServerInterfaces() http.HandlerFunc {
 				newIF.Addrs = append(newIF.Addrs, *cidr)
 			}
 
-			interfaces.Interfaces = append(interfaces.Interfaces, newIF)
+			interfaces = append(interfaces, newIF)
 		}
 
 		body, err := json.Marshal(interfaces)
@@ -378,7 +374,7 @@ func handleAllocate(ns *NetworkState) http.HandlerFunc {
 	}
 }
 
-// handleAddAllowedIPs adds new route to a specfied peer.
+// handleAddAllowedIPs adds new route to a specified peer.
 func handleAddAllowedIPs(devRelay *device.Device, config ServerConfigs) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "POST" {


### PR DESCRIPTION
Adds the `--network-info` (`-n`) boolean flag to the `status` command. For reachable servers, this flag causes a second API request to be made to the new `/serverinterfaces` API route, which returns a list of network interface names and associated CIDRs on the server host. That information is then displayed inside the node. 

This is useful for identifying if the IPs or subnets associated with the server's NICs have changed, for example due to DHCP lease renewal or Docker networking changes. In some cases this will help users quickly figure out how to modify the AllowedIPs associated with the server to restore connectivity to targets. 

Closes #21 