### PR TITLE
Status improvements

### DIFF
--- a/src/cmd/serve.go
+++ b/src/cmd/serve.go
@@ -342,6 +342,7 @@ func (c serveCmdConfig) Run() {
 			},
 		},
 		Addresses: relayAddresses,
+		LocalhostIP: viper.GetString("Relay.Interface.LocalhostIP"),
 	}
 
 	configRelay, err := peer.GetConfig(configRelayArgs)
@@ -598,7 +599,6 @@ func configureLocalhostForwarding(localhostAddr netip.Addr, s *stack.Stack) {
 // Adds a rule to the start of a table chain. 
 func prependIPtableRule(table stack.Table, newRule stack.Rule, chain stack.Hook) (stack.Table) {
 	insertIndex := int(table.BuiltinChains[chain])
-	fmt.Printf("Inserting rule into index %d\n", insertIndex)
 	table.Rules = slices.Insert(table.Rules, insertIndex, newRule)
 
 	// Increment the later chain and underflow index pointers to account for the rule added to the Rules slice

--- a/src/cmd/status.go
+++ b/src/cmd/status.go
@@ -167,6 +167,10 @@ func (cc statusCmdConfig) Run() {
 				api, 
 				strings.Join(ips, ","),
 			)
+
+			if c.relayConfig.GetLocalhostIP() != "" {
+				nodeString += "\n lhost IP: " + c.relayConfig.GetLocalhostIP()
+			}
 			
 			if cc.networkInfo {
 				nodeString += `
@@ -175,7 +179,7 @@ Network Interfaces:
 -------------------
 `
 				for _, ifx := range c.interfaces {
-					nodeString += fmt.Sprintf("%v:\n", ifx.Name)
+					nodeString += ifx.Name + "\n"
 					for _, a := range ifx.Addrs {
 						nodeString += strings.Repeat(" ", 2) + a.String() + "\n"
 					}

--- a/src/peer/config.go
+++ b/src/peer/config.go
@@ -101,6 +101,13 @@ func GetConfig(args ConfigArgs) (Config, error) {
 		}
 	}
 
+	if args.LocalhostIP != "" {
+		err = c.SetLocalhostIP(args.LocalhostIP)
+		if err != nil {
+			return Config{}, err
+		}
+	}
+
 	return c, nil
 }
 
@@ -157,7 +164,6 @@ func ParseConfig(filename string) (c Config, err error) {
 					err = c.SetMTU(mtu)
 				case "localhostip":
 					err = c.SetLocalhostIP(value)
-					fmt.Println("LocalhostIP value parsed")
 				}
 				if err != nil {
 					return c, err
@@ -241,6 +247,7 @@ func (c *Config) UnmarshalJSON(b []byte) error {
 	c.config = tmp.Config
 	c.peers = tmp.Peers
 	c.addresses = tmp.Addresses
+	c.localhostIP = tmp.LocalhostIP
 
 	return nil
 }


### PR DESCRIPTION
`status` command now shows the server's localhost redirection IP, if configured. 

API requests made by the `status` command are now sent to all servers concurrently. This should eliminate long wait times due to multiple servers having connection errors (timeouts). Now `status` should always return data within ~3-5 seconds. 