### PR TITLE
fix ping binary arguments for linux vs macos

### DIFF
--- a/src/transport/icmp/ping.go
+++ b/src/transport/icmp/ping.go
@@ -71,8 +71,10 @@ func (execPing) ping(addr string) (success bool, err error) {
 	switch runtime.GOOS {
 	case "windows":
 		args = []string{pingPath, "-n", "1", "-w", "1000", addr}
-	default:
+	case "darwin":
 		args = []string{pingPath, "-c", "1", "-t", "1", addr}
+	default: //Linux, hopefully any others also use this format
+		args = []string{pingPath, "-c", "1", "-W", "1", addr}
 	}
 
 	cmd := &exec.Cmd{


### PR DESCRIPTION
MacOS ping uses `-t x` to specify a timeout, but on Linux this sets the TTL. Changed to `-W x` when running on Linux. Closes #72 