### PR TITLE
Saving endpoint DNS to config

### DIFF
--- a/src/cmd/serve.go
+++ b/src/cmd/serve.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"net"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -353,7 +354,11 @@ func (c serveCmdConfig) Run() {
 		Peers: []peer.PeerConfigArgs{
 			{
 				PublicKey: viper.GetString("Relay.Peer.publickey"),
-				Endpoint:  viper.GetString("Relay.Peer.endpoint"),
+				Endpoint:  func() string {
+					endpoint, err := net.ResolveUDPAddr("udp", (viper.GetString("Relay.Peer.endpoint")))
+					check("failed to resolve DNS", err)
+					return endpoint.String()
+				}(),
 				PersistentKeepaliveInterval: func() int {
 					if len(viper.GetString("Relay.Peer.endpoint")) > 0 {
 						return viper.GetInt("Relay.Peer.keepalive")

--- a/src/peer/config.go
+++ b/src/peer/config.go
@@ -378,12 +378,22 @@ func (c *Config) GetPeerPublicKey(i int) string {
 
 func (c *Config) GetPeerEndpoint(i int) string {
 	if len(c.peers) > i {
-		endpoint := c.peers[i].config.Endpoint
-		if endpoint != nil {
-			return endpoint.String()
-		}
+		if len(c.peers[i].endpoint) > 0 {
+			endpoint := c.peers[i].endpoint
+			if endpoint != "" {
+				return endpoint
+			}
 
-		return ""
+			return ""
+
+		} else {
+			endpoint := c.peers[i].config.Endpoint
+			if endpoint != nil {
+				return endpoint.String()
+			}
+
+			return ""
+		}
 	}
 
 	return ""


### PR DESCRIPTION
If a DNS name is specified as an endpoint during `configure`, the DNS name gets stored in the configuration file. Name resolution occurs during `serve`.

Addresses issue #87 