### PR TITLE
referencing servers via nickname instead of server address

### DIFF
--- a/src/cmd/add_client.go
+++ b/src/cmd/add_client.go
@@ -143,6 +143,14 @@ func (c addClientCmdConfig) Run() {
 		}
 	} else {
 		// Get leaf server info
+		ip := net.ParseIP(c.serverAddress)
+		if ip == nil {
+			for idx, peer := range baseConfigE2EE.GetPeers() {
+				if peer.GetNickname() == c.serverAddress {
+					c.serverAddress = baseConfigE2EE.GetPeers()[idx].GetApiAddr().String()
+				}
+			}
+		}
 		leafApiAddr, err := netip.ParseAddr(c.serverAddress)
 		check("invalid server address", err)
 		leafApiAddrPort := netip.AddrPortFrom(leafApiAddr, uint16(ApiPort))

--- a/src/cmd/add_server.go
+++ b/src/cmd/add_server.go
@@ -205,6 +205,16 @@ func (c addServerCmdConfig) Run() {
 		check("failed to set addresses", err)
 	} else {
 		// Get leaf server info
+		ip := net.ParseIP(c.serverAddress)
+		if ip == nil {
+			fmt.Println("Server Nickname: "+c.serverAddress)
+			for idx, peer := range clientConfigE2EE.GetPeers() {
+				if peer.GetNickname() == c.serverAddress {
+					c.serverAddress = clientConfigE2EE.GetPeers()[idx].GetApiAddr().String()
+				}
+			}
+		}
+		fmt.Println("Server API: "+c.serverAddress)
 		leafApiAddr, err := netip.ParseAddr(c.serverAddress)
 		check("invalid server address", err)
 		leafApiAddrPort := netip.AddrPortFrom(leafApiAddr, uint16(ApiPort))


### PR DESCRIPTION
This is an initial pass at allowing servers to be referenced via nickname when passing `server-address` during `add client` and `add server`.

Addresses issue #59 