### PR TITLE
updating help messages

### DIFF
--- a/src/cmd/add_client.go
+++ b/src/cmd/add_client.go
@@ -50,7 +50,7 @@ var addClientCmd = &cobra.Command{
 func init() {
 	addCmd.AddCommand(addClientCmd)
 
-	addClientCmd.Flags().StringVarP(&addClientCmdArgs.serverAddress, "server-address", "s", addClientCmdArgs.serverAddress, "API address of server that new client will connect to. By default new clients connect to existing relay servers")
+	addClientCmd.Flags().StringVarP(&addClientCmdArgs.serverAddress, "server-address", "s", addClientCmdArgs.serverAddress, "API address or nickname of server that new client will connect to. By default new clients connect to existing relay servers")
 	addClientCmd.Flags().IntVarP(&addClientCmdArgs.port, "port", "p", addClientCmdArgs.port, "port of wireguard listener to start; server port if --outbound-endpoint, client port otherwise. Default is the port specified in --endpoint")
 	addClientCmd.Flags().IntVarP(&addClientCmdArgs.mtu, "mtu", "m", addClientCmdArgs.mtu, "tunnel MTU")
 

--- a/src/cmd/add_server.go
+++ b/src/cmd/add_server.go
@@ -55,7 +55,7 @@ func init() {
 	addCmd.AddCommand(addServerCmd)
 
 	addServerCmd.Flags().StringSliceVarP(&addServerCmdArgs.allowedIPs, "routes", "r", addServerCmdArgs.allowedIPs, "[REQUIRED] CIDR IP ranges that will be routed through wiretap")
-	addServerCmd.Flags().StringVarP(&addServerCmdArgs.serverAddress, "server-address", "s", addServerCmdArgs.serverAddress, "API address of server that new server will connect to, connects to client by default")
+	addServerCmd.Flags().StringVarP(&addServerCmdArgs.serverAddress, "server-address", "s", addServerCmdArgs.serverAddress, "API address or nickname of server that new server will connect to, connects to client by default")
 	addServerCmd.Flags().IntVarP(&addServerCmdArgs.port, "port", "p", addServerCmdArgs.port, "listener port to start on new server for wireguard relay. If --outbound-endpoint, default is the port specified in --outbound-endpoint; otherwise default is 51820")
 	addServerCmd.Flags().StringVarP(&addServerCmdArgs.nickname, "nickname", "n", addServerCmdArgs.nickname, "Server nickname to display in 'status' command")
 	addServerCmd.Flags().StringVarP(&addServerCmdArgs.localhostIP, "localhost-ip", "i", addServerCmdArgs.localhostIP, "[EXPERIMENTAL] Redirect wiretap packets destined for this IPv4 address to server's localhost")


### PR DESCRIPTION
Adding onto issue #59 from PR #96, the help messages for `server-address` are being updated to include that the nickname can be passed instead of the API address.