### PR TITLE
handling duplicate names

### DIFF
--- a/src/cmd/add_client.go
+++ b/src/cmd/add_client.go
@@ -143,12 +143,22 @@ func (c addClientCmdConfig) Run() {
 		}
 	} else {
 		// Get leaf server info
+		var i int
+		duplicate := make(map[string]int)
 		ip := net.ParseIP(c.serverAddress)
 		if ip == nil {
 			for idx, peer := range baseConfigE2EE.GetPeers() {
 				if peer.GetNickname() == c.serverAddress {
-					c.serverAddress = baseConfigE2EE.GetPeers()[idx].GetApiAddr().String()
+					duplicate[peer.GetNickname()]++
+					i = idx
 				}
+			}
+			if duplicate[c.serverAddress] >= 2 {
+				fmt.Println("Error. There are multiple servers with the nickname "+c.serverAddress)
+				fmt.Printf("Please provide the API address of the server: ")
+				fmt.Scan(&c.serverAddress)
+			} else {
+				c.serverAddress = baseConfigE2EE.GetPeers()[i].GetApiAddr().String()
 			}
 		}
 		leafApiAddr, err := netip.ParseAddr(c.serverAddress)

--- a/src/cmd/add_client.go
+++ b/src/cmd/add_client.go
@@ -156,7 +156,8 @@ func (c addClientCmdConfig) Run() {
 			if duplicate[c.serverAddress] >= 2 {
 				fmt.Println("Error. There are multiple servers with the nickname "+c.serverAddress)
 				fmt.Printf("Please provide the API address of the server: ")
-				fmt.Scan(&c.serverAddress)
+				_, err := fmt.Scan(&c.serverAddress)
+				check("error reading input", err)
 			} else {
 				c.serverAddress = baseConfigE2EE.GetPeers()[i].GetApiAddr().String()
 			}

--- a/src/cmd/add_client.go
+++ b/src/cmd/add_client.go
@@ -154,10 +154,7 @@ func (c addClientCmdConfig) Run() {
 				}
 			}
 			if duplicate[c.serverAddress] >= 2 {
-				fmt.Println("Error. There are multiple servers with the nickname "+c.serverAddress)
-				fmt.Printf("Please provide the API address of the server: ")
-				_, err := fmt.Scan(&c.serverAddress)
-				check("error reading input", err)
+				check("failed to resolve API address", errors.New("there are multiple servers with the nickname "+c.serverAddress))
 			} else {
 				c.serverAddress = baseConfigE2EE.GetPeers()[i].GetApiAddr().String()
 			}

--- a/src/cmd/add_server.go
+++ b/src/cmd/add_server.go
@@ -216,12 +216,7 @@ func (c addServerCmdConfig) Run() {
 				}
 			}
 			if duplicate[c.serverAddress] >= 2 {
-				fmt.Println("Error. There are multiple servers with the nickname "+c.serverAddress)
-				fmt.Printf("Please provide the API address of the server: ")
-				_, err := fmt.Scan(&c.serverAddress)
-				if err != nil {
-					check("error reading input", err)
-				}
+				check("failed to resolve API address", errors.New("there are multiple servers with the nickname "+c.serverAddress))
 			} else {
 				c.serverAddress = clientConfigE2EE.GetPeers()[i].GetApiAddr().String()
 			}

--- a/src/cmd/add_server.go
+++ b/src/cmd/add_server.go
@@ -218,7 +218,10 @@ func (c addServerCmdConfig) Run() {
 			if duplicate[c.serverAddress] >= 2 {
 				fmt.Println("Error. There are multiple servers with the nickname "+c.serverAddress)
 				fmt.Printf("Please provide the API address of the server: ")
-				fmt.Scan(&c.serverAddress)
+				_, err := fmt.Scan(&c.serverAddress)
+				if err != nil {
+					check("error reading input", err)
+				}
 			} else {
 				c.serverAddress = clientConfigE2EE.GetPeers()[i].GetApiAddr().String()
 			}

--- a/src/cmd/add_server.go
+++ b/src/cmd/add_server.go
@@ -205,16 +205,24 @@ func (c addServerCmdConfig) Run() {
 		check("failed to set addresses", err)
 	} else {
 		// Get leaf server info
+		var i int
+		duplicate := make(map[string]int)
 		ip := net.ParseIP(c.serverAddress)
 		if ip == nil {
-			fmt.Println("Server Nickname: "+c.serverAddress)
 			for idx, peer := range clientConfigE2EE.GetPeers() {
 				if peer.GetNickname() == c.serverAddress {
-					c.serverAddress = clientConfigE2EE.GetPeers()[idx].GetApiAddr().String()
+					duplicate[peer.GetNickname()]++
+					i = idx
 				}
 			}
+			if duplicate[c.serverAddress] >= 2 {
+				fmt.Println("Error. There are multiple servers with the nickname "+c.serverAddress)
+				fmt.Printf("Please provide the API address of the server: ")
+				fmt.Scan(&c.serverAddress)
+			} else {
+				c.serverAddress = clientConfigE2EE.GetPeers()[i].GetApiAddr().String()
+			}
 		}
-		fmt.Println("Server API: "+c.serverAddress)
 		leafApiAddr, err := netip.ParseAddr(c.serverAddress)
 		check("invalid server address", err)
 		leafApiAddrPort := netip.AddrPortFrom(leafApiAddr, uint16(ApiPort))


### PR DESCRIPTION
When assigning names to servers, there is nothing that prevents multiple servers having the same name. In the event that there are duplicates when passing a nickname to `server-address`, wiretap will require the API address to be passed to ensure the correct connection.

Addresses issue #59 