### PR TITLE
More PSK support

### DIFF
--- a/src/cmd/add.go
+++ b/src/cmd/add.go
@@ -35,7 +35,7 @@ func init() {
 
 	addCmd.PersistentFlags().StringVarP(&addCmdArgs.endpoint, "endpoint", "e", addCmdArgs.endpoint, "IP:PORT (or [IP]:PORT for IPv6) of wireguard listener that server will connect to (example \"1.2.3.4:51820\")")
 	addCmd.PersistentFlags().StringVarP(&addCmdArgs.outboundEndpoint, "outbound-endpoint", "o", addCmdArgs.outboundEndpoint, "IP:PORT (or [IP]:PORT for IPv6) of wireguard listener that client will connect to (example \"4.3.2.1:51820\"")
-	addCmd.PersistentFlags().BoolVarP(&addCmdArgs.generatePSK, "PSK", "K", addCmdArgs.generatePSK, "generate a preshared key")
+	addCmd.PersistentFlags().BoolVarP(&addCmdArgs.generatePSK, "PSK", "K", addCmdArgs.generatePSK, "configure a random preshared key; currently only applies to first-hop relay connections")
 
 	addCmd.PersistentFlags().IntVarP(&addCmdArgs.keepalive, "keepalive", "k", addCmdArgs.keepalive, "tunnel keepalive in seconds")
 

--- a/src/cmd/add.go
+++ b/src/cmd/add.go
@@ -10,6 +10,7 @@ type addCmdConfig struct {
 	endpoint         string
 	outboundEndpoint string
 	keepalive        int
+	generatePSK      bool
 }
 
 // Defaults for add command.
@@ -18,6 +19,7 @@ var addCmdArgs = addCmdConfig{
 	endpoint:         Endpoint,
 	outboundEndpoint: Endpoint,
 	keepalive:        Keepalive,
+	generatePSK:      false,
 }
 
 // addCmd represents the add command.
@@ -33,6 +35,7 @@ func init() {
 
 	addCmd.PersistentFlags().StringVarP(&addCmdArgs.endpoint, "endpoint", "e", addCmdArgs.endpoint, "IP:PORT (or [IP]:PORT for IPv6) of wireguard listener that server will connect to (example \"1.2.3.4:51820\")")
 	addCmd.PersistentFlags().StringVarP(&addCmdArgs.outboundEndpoint, "outbound-endpoint", "o", addCmdArgs.outboundEndpoint, "IP:PORT (or [IP]:PORT for IPv6) of wireguard listener that client will connect to (example \"4.3.2.1:51820\"")
+	addCmd.PersistentFlags().BoolVarP(&addCmdArgs.generatePSK, "PSK", "K", addCmdArgs.generatePSK, "generate a preshared key")
 
 	addCmd.PersistentFlags().IntVarP(&addCmdArgs.keepalive, "keepalive", "k", addCmdArgs.keepalive, "tunnel keepalive in seconds")
 

--- a/src/cmd/add_client.go
+++ b/src/cmd/add_client.go
@@ -198,6 +198,15 @@ func (c addClientCmdConfig) Run() {
 	// Make peer configs to populate server peers.
 	clientPeerConfigRelay, err := peer.GetPeerConfig(peer.PeerConfigArgs{
 		PublicKey: clientConfigRelay.GetPublicKey(),
+		PresharedKey: func() string {
+			if addArgs.generatePSK {
+				err := clientConfigRelay.GenPresharedKey()
+				check("failed to generate preshared key", err)
+				return clientConfigRelay.GetPresharedKey()
+			} else {
+				return ""
+			}
+		}(),
 		AllowedIPs: func() []string {
 			allowed := []string{}
 			for _, prefix := range clientConfigRelay.GetAddresses() {

--- a/src/cmd/add_server.go
+++ b/src/cmd/add_server.go
@@ -142,6 +142,15 @@ func (c addServerCmdConfig) Run() {
 		// Add new server as relay peer.
 		serverRelayPeer, err := peer.GetPeerConfig(peer.PeerConfigArgs{
 			PublicKey: serverConfigRelay.GetPublicKey(),
+			PresharedKey: func() string {
+				if addArgs.generatePSK {
+					err := serverConfigRelay.GenPresharedKey()
+					check("failed to generate preshared key", err)
+					return serverConfigRelay.GetPresharedKey()
+				} else {
+					return ""
+				}
+			}(),
 			AllowedIPs: func() []string {
 				allowedIPs := []string{}
 				for _, prefix := range newRelayPrefixes {

--- a/src/cmd/configure.go
+++ b/src/cmd/configure.go
@@ -91,7 +91,7 @@ func init() {
 	configureCmd.Flags().IntVarP(&configureCmdArgs.sport, "sport", "S", configureCmdArgs.sport, "listener port for server wireguard relay. Default is to copy the --outbound-endpoint port, or fallback to 51820")
 	configureCmd.Flags().StringVarP(&configureCmdArgs.nickname, "nickname", "n", configureCmdArgs.nickname, "Server nickname to display in 'status' command")
 	configureCmd.Flags().StringVarP(&configureCmdArgs.localhostIP, "localhost-ip", "i", configureCmdArgs.localhostIP, "[EXPERIMENTAL] Redirect wiretap packets destined for this IPv4 address to server's localhost")
-	configureCmd.Flags().BoolVarP(&configureCmdArgs.generatePSK, "PSK", "K", configureCmdArgs.generatePSK, "generates a preshared key")
+	configureCmd.Flags().BoolVarP(&configureCmdArgs.generatePSK, "PSK", "K", configureCmdArgs.generatePSK, "configure a random preshared key; currently only applies to first-hop relay connections")
 
 	configureCmd.Flags().StringVarP(&configureCmdArgs.configFileRelay, "relay-output", "", configureCmdArgs.configFileRelay, "wireguard relay config output filename")
 	configureCmd.Flags().StringVarP(&configureCmdArgs.configFileE2EE, "e2ee-output", "", configureCmdArgs.configFileE2EE, "wireguard E2EE config output filename")


### PR DESCRIPTION
Adds PSK support for the `add` commands, but only when adding a new first-hop server or client, and only for the relay connection. 