### PR TITLE
Add option to disable api

### DIFF
--- a/src/cmd/configure.go
+++ b/src/cmd/configure.go
@@ -32,13 +32,14 @@ type configureCmdConfig struct {
 	clientAddr6E2EE  string
 	serverAddr4Relay string
 	serverAddr6Relay string
+	disableApi       bool
 	apiAddr          string
 	apiv4Addr        string
 	keepalive        int
 	mtu              int
 	disableV6        bool
 	localhostIP      string
-	generatePSK		 bool
+	generatePSK      bool
 }
 
 // Defaults for configure command.
@@ -61,13 +62,14 @@ var configureCmdArgs = configureCmdConfig{
 	clientAddr6E2EE:  ClientE2EESubnet6.Addr().Next().String() + "/128",
 	serverAddr4Relay: RelaySubnets4.Addr().Next().Next().String() + "/32",
 	serverAddr6Relay: RelaySubnets6.Addr().Next().Next().String() + "/128",
+	disableApi:       false,
 	apiAddr:          ApiSubnets.Addr().Next().Next().String() + "/128",
 	apiv4Addr:        ApiV4Subnets.Addr().Next().Next().String() + "/32",
 	keepalive:        Keepalive,
 	mtu:              MTU,
 	disableV6:        false,
 	localhostIP:      "",
-	generatePSK:	  false,
+	generatePSK:      false,
 }
 
 // configureCmd represents the configure command.
@@ -99,6 +101,7 @@ func init() {
 	configureCmd.Flags().BoolVarP(&configureCmdArgs.writeToClipboard, "clipboard", "c", configureCmdArgs.writeToClipboard, "copy configuration args to clipboard")
 	configureCmd.Flags().BoolVarP(&configureCmdArgs.simple, "simple", "", configureCmdArgs.simple, "disable multihop and multiclient features for a simpler setup")
 
+	configureCmd.Flags().BoolVarP(&configureCmdArgs.disableApi, "disable-api", "", configureCmdArgs.disableApi, "disables server API service")
 	configureCmd.Flags().StringVarP(&configureCmdArgs.apiAddr, "api", "0", configureCmdArgs.apiAddr, "address of server API service")
 	configureCmd.Flags().IntVarP(&configureCmdArgs.keepalive, "keepalive", "k", configureCmdArgs.keepalive, "tunnel keepalive in seconds, only applies to outbound handshakes")
 	configureCmd.Flags().IntVarP(&configureCmdArgs.mtu, "mtu", "m", configureCmdArgs.mtu, "tunnel MTU")
@@ -131,6 +134,7 @@ func init() {
 				"ipv6-relay-server",
 				"keepalive",
 				"mtu",
+				"disable-api",
 				"disable-ipv6",
 				"relay-output",
 				"e2ee-output",
@@ -158,7 +162,10 @@ func (c configureCmdConfig) Run() {
 	if c.disableV6 && netip.MustParsePrefix(c.apiAddr).Addr().Is6() {
 		c.apiAddr = c.apiv4Addr
 	}
-	c.allowedIPs = append(c.allowedIPs, c.apiAddr)
+
+	if !c.disableApi {
+		c.allowedIPs = append(c.allowedIPs, c.apiAddr)
+	}
 
 	// Generate client and server configs.
 	serverConfigRelayArgs := peer.ConfigArgs{}

--- a/src/cmd/serve.go
+++ b/src/cmd/serve.go
@@ -53,6 +53,7 @@ type serveCmdConfig struct {
 	keepaliveIdle     uint
 	keepaliveCount    uint
 	keepaliveInterval uint
+	disableApi        bool
 	disableV6         bool
 	localhostIP       string
 }
@@ -90,6 +91,7 @@ var serveCmd = serveCmdConfig{
 	keepaliveIdle:     60,
 	keepaliveCount:    3,
 	keepaliveInterval: 60,
+	disableApi:        false,
 	disableV6:         false,
 	localhostIP:       "",
 }
@@ -137,6 +139,7 @@ func init() {
 	cmd.Flags().BoolVarP(&serveCmd.logging, "log", "l", serveCmd.logging, "enable logging to file")
 	cmd.Flags().StringVarP(&serveCmd.logFile, "log-file", "o", serveCmd.logFile, "write log to this filename")
 	cmd.Flags().StringVarP(&serveCmd.localhostIP, "localhost-ip", "i", serveCmd.localhostIP, "[EXPERIMENTAL] redirect Wiretap packets destined for this IPv4 address to server's localhost")
+	cmd.Flags().BoolVarP(&serveCmd.disableApi, "disable-api", "", serveCmd.disableApi, "disable API service")
 	cmd.Flags().StringP("api", "0", wiretapDefault.apiAddr, "address of API service")
 	cmd.Flags().IntP("keepalive", "k", wiretapDefault.keepalive, "tunnel keepalive in seconds")
 	cmd.Flags().IntP("mtu", "m", wiretapDefault.mtu, "tunnel MTU")
@@ -207,6 +210,8 @@ func init() {
 	check("error binding flag to viper", err)
 	err = viper.BindPFlag("E2EE.Interface.ipv6", cmd.Flags().Lookup("ipv6-e2ee"))
 	check("error binding flag to viper", err)
+	err = viper.BindPFlag("disableapi", cmd.Flags().Lookup("disable-api"))
+	check("error binding flag to viper", err)
 	err = viper.BindPFlag("E2EE.Interface.api", cmd.Flags().Lookup("api"))
 	check("error binding flag to viper", err)
 
@@ -262,6 +267,7 @@ func init() {
 				"keepalive-interval",
 				"keepalive-count",
 				"keepalive-idle",
+				"disable-api",
 				"disable-ipv6",
 			} {
 				err := cmd.Flags().MarkHidden(f)
@@ -363,7 +369,7 @@ func (c serveCmdConfig) Run() {
 				Endpoint: func() string {
 					if len(viper.GetString("Relay.Peer.endpoint")) > 0 {
 						endpoint, err := net.ResolveUDPAddr("udp", (viper.GetString("Relay.Peer.endpoint")))
-						check("failed to resolve endpoint DNS name for '" + viper.GetString("Relay.Peer.endpoint") + "'", err)
+						check("failed to resolve endpoint DNS name for '"+viper.GetString("Relay.Peer.endpoint")+"'", err)
 						return endpoint.String()
 					} else {
 						return ""
@@ -605,23 +611,25 @@ func (c serveCmdConfig) Run() {
 		wg.Done()
 	}()
 
-	// Start API handler.
-	wg.Add(1)
-	go func() {
-		ns := api.NetworkState{
-			NextClientRelayAddr4: netip.MustParseAddr(c.clientAddr4Relay),
-			NextClientRelayAddr6: netip.MustParseAddr(c.clientAddr6Relay),
-			NextServerRelayAddr4: netip.MustParseAddr(viper.GetString("Relay.Interface.ipv4")),
-			NextServerRelayAddr6: netip.MustParseAddr(viper.GetString("Relay.Interface.ipv6")),
-			NextClientE2EEAddr4:  netip.MustParseAddr(c.clientAddr4E2EE),
-			NextClientE2EEAddr6:  netip.MustParseAddr(c.clientAddr6E2EE),
-			NextServerE2EEAddr4:  netip.MustParseAddr(viper.GetString("E2EE.Interface.ipv4")),
-			NextServerE2EEAddr6:  netip.MustParseAddr(viper.GetString("E2EE.Interface.ipv6")),
-			ApiAddr:              netip.MustParseAddr(viper.GetString("E2EE.Interface.api")),
-		}
-		api.Handle(transportHandler, devRelay, devE2EE, &configRelay, &configE2EE, apiAddr, uint16(ApiPort), &lock, &ns)
-		wg.Done()
-	}()
+	if !viper.IsSet("disableapi") {
+		// Start API handler.
+		wg.Add(1)
+		go func() {
+			ns := api.NetworkState{
+				NextClientRelayAddr4: netip.MustParseAddr(c.clientAddr4Relay),
+				NextClientRelayAddr6: netip.MustParseAddr(c.clientAddr6Relay),
+				NextServerRelayAddr4: netip.MustParseAddr(viper.GetString("Relay.Interface.ipv4")),
+				NextServerRelayAddr6: netip.MustParseAddr(viper.GetString("Relay.Interface.ipv6")),
+				NextClientE2EEAddr4:  netip.MustParseAddr(c.clientAddr4E2EE),
+				NextClientE2EEAddr6:  netip.MustParseAddr(c.clientAddr6E2EE),
+				NextServerE2EEAddr4:  netip.MustParseAddr(viper.GetString("E2EE.Interface.ipv4")),
+				NextServerE2EEAddr6:  netip.MustParseAddr(viper.GetString("E2EE.Interface.ipv6")),
+				ApiAddr:              netip.MustParseAddr(viper.GetString("E2EE.Interface.api")),
+			}
+			api.Handle(transportHandler, devRelay, devE2EE, &configRelay, &configE2EE, apiAddr, uint16(ApiPort), &lock, &ns)
+			wg.Done()
+		}()
+	}
 
 	wg.Wait()
 }


### PR DESCRIPTION
I have a usecase where I want to give users a wireguard config without them being able to use the api, therefore an option to disable it would be great.